### PR TITLE
Remove unused function createThin()

### DIFF
--- a/runtime/Go/antlr/v4/common_token_factory.go
+++ b/runtime/Go/antlr/v4/common_token_factory.go
@@ -47,10 +47,3 @@ func (c *CommonTokenFactory) Create(source *TokenSourceCharStreamPair, ttype int
 
 	return t
 }
-
-func (c *CommonTokenFactory) createThin(ttype int, text string) Token {
-	t := NewCommonToken(nil, ttype, TokenDefaultChannel, -1, -1)
-	t.SetText(text)
-
-	return t
-}

--- a/runtime/JavaScript/src/antlr4/CommonTokenFactory.js
+++ b/runtime/JavaScript/src/antlr4/CommonTokenFactory.js
@@ -43,12 +43,6 @@ export default class CommonTokenFactory extends TokenFactory {
         }
         return t;
     }
-
-    createThin(type, text) {
-        const t = new CommonToken(null, type);
-        t.text = text;
-        return t;
-    }
 }
 
 /**

--- a/runtime/Python3/src/antlr4/CommonTokenFactory.py
+++ b/runtime/Python3/src/antlr4/CommonTokenFactory.py
@@ -53,9 +53,4 @@ class CommonTokenFactory(TokenFactory):
             t.text = source[1].getText(start,stop)
         return t
 
-    def createThin(self, type:int, text:str):
-        t = CommonToken(type=type)
-        t.text = text
-        return t
-
 CommonTokenFactory.DEFAULT = CommonTokenFactory()


### PR DESCRIPTION
The unexported function 'antlr.createThin' is never used but has a potential bug. Using nil constant at common_token_factory.go:52, it is passed as 1st parameter in call to function 'antlr.NewCommonToken' at common_token_factory.go:52, where it is dereferenced at token.go:140.
